### PR TITLE
Do not require forecast dates for Not Recommended Series Status

### DIFF
--- a/cds-tcamt/cds-tcamt-client/app/scripts/controllers/testplans.js
+++ b/cds-tcamt/cds-tcamt-client/app/scripts/controllers/testplans.js
@@ -951,7 +951,7 @@ angular
                 return angular.element(document.getElementById(id)).scope();
             };
 
-            $scope.noDatesSS = ['G','F','A','I','S','C','X'];
+            $scope.noDatesSS = ['G','F','A','I','S','C','X','R'];
 
             $scope.needDates = function (ss) {
                 return !~$scope.noDatesSS.indexOf(ss);


### PR DESCRIPTION
When selecting a status of 'Not Recommended' dates are being required.

Looking at the [defined enums used](https://github.com/usnistgov/cds-base/blob/42dfe0f69e21303fb97e1a7eb51420034990b358/cds-base/cds-base-domain/src/main/java/gov/nist/healthcare/cds/enumeration/SerieStatus.java), it seems to confirm that dates should not be required for this selection.

Adding the 'R' (Not Recommended) to the array will allow for the forecast to be created without defining dates.